### PR TITLE
Save palette styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,48 +10,74 @@
         </title>
     </head>
     <body>
-        <header>
-            <strong>COLORANDOM</strong>
-        </header>
-        <section class="main-display">
-            <div class="color-container">
-                <div class="color-box" id="b1">
-                    <img src="./assets/unlocked.png" class="lock-box">
+        <main>
+            <header>
+                <h1>COLORANDOM</h1>
+            </header>
+            <section class="main-display">
+                <div class="color-container">
+                    <div class="color-box" id="b1">
+                        <img src="./assets/unlocked.png" class="lock-box">
+                    </div>
+                    <div class="hex-code">#EA9999</div>
                 </div>
-                <div class="hex-code">#EA9999</div>
-            </div>
-            <div class="color-container">
-                <div class="color-box" id="b2">
-                    <img src="./assets/unlocked.png" class="lock-box">
+                <div class="color-container">
+                    <div class="color-box" id="b2">
+                        <img src="./assets/unlocked.png" class="lock-box">
+                    </div>
+                    <div class="hex-code">#FACB9C</div>
                 </div>
-                <div class="hex-code">#FACB9C</div>
-            </div>
-            <div class="color-container">
-                <div class="color-box" id="b3">
-                    <img src="./assets/unlocked.png" class="lock-box">
+                <div class="color-container">
+                    <div class="color-box" id="b3">
+                        <img src="./assets/unlocked.png" class="lock-box">
+                    </div>
+                    <div class="hex-code">#FFE59A</div>
                 </div>
-                <div class="hex-code">#FFE59A</div>
-            </div>
-            <div class="color-container">
-                <div class="color-box" id="b4">
-                    <img src="./assets/unlocked.png" class="lock-box">
+                <div class="color-container">
+                    <div class="color-box" id="b4">
+                        <img src="./assets/unlocked.png" class="lock-box">
+                    </div>
+                    <div class="hex-code">#B6D7A8</div>
                 </div>
-                <div class="hex-code">#B6D7A8</div>
-            </div>
-            <div class="color-container">
-                <div class="color-box" id="b5">
-                    <img src="./assets/unlocked.png" class="lock-box">
+                <div class="color-container">
+                    <div class="color-box" id="b5">
+                        <img src="./assets/unlocked.png" class="lock-box">
+                    </div>
+                    <div class="hex-code">#A4C4CA</div>
                 </div>
-                <div class="hex-code">#A4C4CA</div>
-            </div>
-        </section>
-        <section class="button-area">
-            <div class="button-box-l"></div>
-            <button id="new-palette">
-                New Palette
-            </button>
-            <div class="button-box-r"></div>
-        </section>
+            </section>
+            <section class="button-area">
+                <div class="button-box-l"></div>
+                <button id="new-palette">
+                    New Palette
+                </button>
+                <div class="button-box-r"></div>
+                <div class="button-box-l"></div>
+                <button id="save-palette">
+                    Save Palette
+                </button>
+                <div class="button-box-r"></div>
+            </section>
+        </main>
+         <!-- <div> -->
+            <section class="save-container">
+                <h2>Saved Pallettes</h3>
+                    <div class="mini-container">
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                    </div>
+                    <div class="mini-container">
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                        <div class="mini-box"></div>
+                    </div>
+            </section>
+         <!-- </div> -->
         <script src="./main.js"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -59,25 +59,13 @@
                 <div class="button-box-r"></div>
             </section>
         </main>
-         <!-- <div> -->
             <section class="save-container">
-                <h2>Saved Pallettes</h3>
-                    <div class="mini-container">
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                    </div>
-                    <div class="mini-container">
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                        <div class="mini-box"></div>
-                    </div>
-            </section>
-         <!-- </div> -->
+                <h2>Saved Palettes</h3>
+                <p>No saved palettes yet!</p>
+                    <section class="mini-palettes">
+                        <!-- Saved palettes gets populated here -->
+                    </section>
+                </section>
         <script src="./main.js"></script>
     </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -21,9 +21,17 @@ main {
     min-width: 950px;
 }
 
+h1 {
+    margin: 0;
+}
+
 h2 {
     font-size: 2.3rem;
     margin: 0 0 30px 0;
+}
+
+p {
+    font-size: 1.5rem;
 }
 
 header {
@@ -138,4 +146,8 @@ button {
 
 #b5 {
     background-color: #A4C4CA;
+}
+
+.hidden {
+    display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -40,7 +40,8 @@ header {
     text-align: center;
 }
 
-section {
+.main-display,
+.button-area {
     display: flex;
     justify-content: center;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,19 +1,34 @@
+* {
+    font-family: 'Poppins', sans-serif;
+}
+
 html {
     height: 100%;
     background-color: #e7f1f1;
 }
-
 body {
+    height: 100%;
+    display: flex;
+}
+
+main {
     height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
+    width: 75%;
+    border-right: 5px solid #000000;
+    min-width: 950px;
+}
+
+h2 {
+    font-size: 2.3rem;
+    margin: 0 0 30px 0;
 }
 
 header {
-    font-family: 'Poppins', sans-serif;
     font-weight: bolder;
-    font-size: 4rem;
+    font-size: 3rem;
     text-align: center;
 }
 
@@ -22,8 +37,19 @@ section {
     justify-content: center;
 }
 
+.save-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    text-align: center;
+    width: 25%;
+    margin-top: 35px;
+    min-width: 350px;
+}
+
 button {
-    font-family: 'Poppins', sans-serif;
+    
     background-color: #000000;
     color: #FFFFFF;
     padding-top: 10px;
@@ -31,20 +57,23 @@ button {
     font-size: x-large;
     font-weight: 200;
     border: none;
+    white-space: nowrap;
 }
 
 .button-box-l {
     height: auto;
-    width: 50px;
+    min-width: 50px;
     background-color: #000000;
     border-bottom-left-radius: 100%;
+    margin-left: 100px;
 }
 
 .button-box-r {
     height: auto;
-    width: 50px;
+    min-width: 50px;
     background-color: #000000;
     border-top-right-radius: 100%;
+    margin-right: 100px;
 }
 
 .color-container {
@@ -55,7 +84,19 @@ button {
     position: relative;
     height: 150px;
     width: 150px;
-    border: solid;
+    border: 5px solid;
+}
+
+.mini-container {
+    display: flex;
+    margin-bottom: 25px;
+}
+
+.mini-box {
+    height: 40px;
+    width: 40px;
+    border: 4px solid;
+    margin: 0 4px;
 }
 
 .lock-box {
@@ -73,7 +114,6 @@ button {
 }
 
 .hex-code {
-    font-family: 'Poppins', sans-serif;
     text-align: center;
     font-weight: 400;
     padding-top: 5px;


### PR DESCRIPTION
This pull request features styling for a saved palette section using `<div>` and `<section>` as flex containers. Minimum size boxes were specified to avoid having the sections overlap when the screen shrinks to a certain size. 
The feature was tested by refreshing and changing the size of the browser window. 

This PR will close #12 
