### PR TITLE
Add delete palette html and functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,8 +24,16 @@ buttonSection.addEventListener('click', function(event) {
 });
 
 buttonSection.addEventListener('click', function(event) {
-    if (event.target.classList.contains('save-palette')) {
+    if(event.target.classList.contains('save-palette')) {
         savePalette();
+    }
+});
+
+savedPalettesSection.addEventListener('click', function(event) {
+    if(event.target.classList.contains('delete-button')) {
+        var eventTargetParent = event.target.parentNode
+        var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
+        deletePalette(eventTargetParent, thisSavedPaletteIndex);
     }
 });
 
@@ -65,6 +73,11 @@ function savePalette() {
     getNewHexes();
 }
 
+function deletePalette(savedPalette, savedPalettesIndex) {
+    savedPalettes.splice(savedPalettesIndex, 1);
+    savedPalette.remove();
+}
+
 function displaySavedPalettesSection() {
     savedPalettesSection.innerHTML = '';
     if (!savedPalettes.length) {
@@ -72,15 +85,16 @@ function displaySavedPalettesSection() {
     } else {
         p.classList.add('hidden');
         for (i = 0; i < savedPalettes.length; i++) {
-        savedPalettesSection.innerHTML += `
-        <div class="mini-container">
-            <div class="mini-box", style="background-color: #${savedPalettes[i][0]}"></div>
-            <div class="mini-box", style="background-color: #${savedPalettes[i][1]}"></div>
-            <div class="mini-box", style="background-color: #${savedPalettes[i][2]}"></div>
-            <div class="mini-box", style="background-color: #${savedPalettes[i][3]}"></div>
-            <div class="mini-box", style="background-color: #${savedPalettes[i][4]}"></div>
-        </div>
-        `
+            savedPalettesSection.innerHTML += `
+                <div class="mini-container">
+                    <div class="mini-box" style="background-color: #${savedPalettes[i][0]}"></div>
+                    <div class="mini-box" style="background-color: #${savedPalettes[i][1]}"></div>
+                    <div class="mini-box" style="background-color: #${savedPalettes[i][2]}"></div>
+                    <div class="mini-box" style="background-color: #${savedPalettes[i][3]}"></div>
+                    <div class="mini-box" style="background-color: #${savedPalettes[i][4]}"></div>
+                    <img class="delete-button" src='./assets/delete.png'></img>
+                </div>
+            `
         };
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -98,7 +98,9 @@ button {
 
 .mini-container {
     display: flex;
+    align-items: center;
     margin-bottom: 25px;
+    margin-left: 10px;
 }
 
 .mini-box {
@@ -106,6 +108,13 @@ button {
     width: 40px;
     border: 4px solid;
     margin: 0 4px;
+}
+
+.delete-button {
+    height: 38px;
+    width: 38px;
+    border: none;
+    padding: 0 20px;
 }
 
 .lock-box {


### PR DESCRIPTION
## What is the feature?
The adds the user feature to delete individual saved palettes

## How you implemented the solution?
- I added the `X` source image to each HTML mini-container generated in `displaySavedPalettesSection()`
- attached an event listener for any click on one of these elements
- delete the selected saved palette from the front end and our data

## Any changes in the UI (Screenshots)?
Yep, a big fat `X` next to each saved palette

## How to test the feature (A test scenario or any new setup)?
- Ensure all previous functionality still works
- A delete `X` appears next to each saved palette
  - It is centered properly compared to the color boxes
  - there is sufficient padding on either side of the `X` per the spec
- When deleted, the specified palette container is deleted and the corresponding data in our model is also deleted
  - A good way to test this from the front-end is to try and save a new palette after deletion(s)
