### PR TITLE
Finish uniquePalettes function.

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,8 +59,28 @@ function getRandomHex() {
     return (Math.floor(Math.random() * 16777216).toString(16).padStart(6, 0));
 }
 
+function uniquePalettes(palettesList, singlePalette) {
+    for (i = 0; i < palettesList.length; i++) {
+        var matches = true;
+        for (j = 0; j < palettesList[i].length; j++) {
+            if (palettesList[i][j] !== singlePalette[j]) {
+                matches = false;
+                break;
+            }
+        }
+        if (matches) {
+            return false;
+        }
+    }    
+    return true;
+}
+
 function savePalette() {
-    savedPalettes.push(currentPalette)
+    if (!savedPalettes.length) {
+        savedPalettes.push(currentPalette)
+    } else if (uniquePalettes(savedPalettes, currentPalette)) {
+        savedPalettes.push(currentPalette)
+    }
     displaySavedPalettesSection();
     getNewHexes();
 }


### PR DESCRIPTION
## What is the feature?
This feature prevents any palettes that are already saved to be saved, exactly the same way, again.

## How you implemented the solution?
Double for loop function that checks our savedPalettes array by index index (yes index index), and compares that to the currentPalette indexes. If the palette already exists in savedPalettes, it won't allow it to be saved again.

## Does it impact any other area of the project?
It shouldn't impact much else besides the save palette feature.

## How to test the feature (A test scenario or any new setup)?
Save a palette. Lock all boxes, try to save again. What was that? YOU CAN'T
