### PR TITLE
Adds the delete palette confirmation modal and functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,13 +59,18 @@
                 <div class="button-box-r save-palette"></div>
             </section>
         </main>
-            <section class="save-container">
-                <h2>Saved Palettes</h2>
-                <p>No saved palettes yet!</p>
-                    <section class="mini-palettes">
-                        <!-- Saved palettes gets populated here -->
-                    </section>
-                </section>
+        <section class="save-container">
+            <h2>Saved Palettes</h2>
+            <p>No saved palettes yet!</p>
+            <section class="mini-palettes">
+                <!-- Saved palettes gets populated here -->
+            </section>
+        </section>
+        <div class="modal-window hidden">
+            <img class="modal-exit-button" src='./assets/delete.png'></img>
+            <span id="modalText">Are you sure you want to delete this palette?</span>
+            <button id="deletePaletteButton">Delete this palette</button>
+        </div>
         <script src="./main.js"></script>
     </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
 var savedPalettes = [];
 var currentPalette = [];
+var shouldDelete = false;
 
+var main = document.querySelector('main');
+var savedContainer = document.querySelector('.save-container')
 var buttonSection = document.querySelector('.button-area');
 var newPaletteButton = document.querySelector('button');
 var mainColorBoxes = document.querySelectorAll('.color-container');
@@ -31,21 +34,23 @@ buttonSection.addEventListener('click', function(event) {
     }
 });
 
-
-var shouldDelete = false;
 savedPalettesSection.addEventListener('click', async function(event) {
     if(event.target.classList.contains('delete-button')) {
         deleteModal.classList.toggle('hidden');
+        main.classList.toggle('block');
+        savedContainer.classList.toggle('block');
         await getPromiseFromEvent(deleteModal, 'click')
         if(shouldDelete) {
             var eventTargetParent = event.target.parentNode
             var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
             deletePalette(eventTargetParent, thisSavedPaletteIndex);
-        } else if (event.target.classList.contains('mini-box')){
-            displayMainColours(getSavedPalette(event));
-        }
+        } 
         deleteModal.classList.toggle('hidden');
+        main.classList.toggle('block');
+        savedContainer.classList.toggle('block');
         shouldDelete = false;
+    } else if (event.target.classList.contains('mini-box')) {
+        displayMainColours(getSavedPalette(event));
     }
 });
 

--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ savedPalettesSection.addEventListener('click', async function(event) {
 
 function getPromiseFromEvent(element, listenerName) {
     return new Promise(function (resolve) {
-        var listener = event => {
+        function listener(event) {
             if(event.target.classList.contains('modal-exit-button')) {
                 shouldDelete = false;
             } else if(event.target.nodeName === 'BUTTON') {

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ var mainColorBoxes = document.querySelectorAll('.color-container');
 var lockButton = document.querySelector('.main-display');
 var savedPalettesSection = document.querySelector('.mini-palettes')
 var p = document.querySelector('p')
+var deleteModal = document.querySelector('.modal-window')
 
 window.addEventListener('load', getNewHexes);
 
@@ -29,13 +30,36 @@ buttonSection.addEventListener('click', function(event) {
     }
 });
 
-savedPalettesSection.addEventListener('click', function(event) {
+
+var shouldDelete = false;
+savedPalettesSection.addEventListener('click', async function(event) {
     if(event.target.classList.contains('delete-button')) {
-        var eventTargetParent = event.target.parentNode
-        var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
-        deletePalette(eventTargetParent, thisSavedPaletteIndex);
+        deleteModal.classList.toggle('hidden');
+        await getPromiseFromEvent(deleteModal, 'click')
+        if(shouldDelete) {
+            var eventTargetParent = event.target.parentNode
+            var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
+            deletePalette(eventTargetParent, thisSavedPaletteIndex);
+        }
+        deleteModal.classList.toggle('hidden');
+        shouldDelete = false;
     }
 });
+
+function getPromiseFromEvent(element, listenerName) {
+    return new Promise(function (resolve) {
+        var listener = event => {
+            if(event.target.classList.contains('modal-exit-button')) {
+                shouldDelete = false;
+            } else if(event.target.nodeName === 'BUTTON') {
+                shouldDelete = true;
+            }
+            element.removeEventListener(listenerName, listener);
+            resolve(event);
+        };
+        element.addEventListener(listenerName, listener);
+    });
+}
 
 function getNewHexes() {
     var oldHexes = currentPalette

--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,6 @@ header {
 }
 
 button {
-    
     background-color: #000000;
     color: #FFFFFF;
     padding-top: 10px;
@@ -156,6 +155,33 @@ button {
 
 #b5 {
     background-color: #A4C4CA;
+}
+
+.modal-window {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-around;
+    height: 350px;
+    width: 350px;
+    border: 4px solid;
+    border-radius: 10%;
+    font-size: x-large;
+}
+
+#modalText {
+    padding: 10px;
+}
+
+#deletePaletteButton {
+    border-radius: 15px;
+}
+
+.modal-exit-button {
+    height: 38px;
+    width: 38px;
+    border: none;
+    padding-left: 60%;
 }
 
 .hidden {

--- a/styles.css
+++ b/styles.css
@@ -163,8 +163,13 @@ button {
     flex-direction: column;
     align-items: center;
     justify-content: space-around;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     height: 350px;
     width: 350px;
+    background-color: #e7f1f1;
     border: 4px solid;
     border-radius: 10%;
     font-size: x-large;
@@ -172,6 +177,7 @@ button {
 
 #modalText {
     padding: 10px;
+    text-align: center;
 }
 
 #deletePaletteButton {
@@ -187,4 +193,9 @@ button {
 
 .hidden {
     display: none;
+}
+
+.block {
+    pointer-events: none;
+    opacity: 0.3;
 }

--- a/styles.css
+++ b/styles.css
@@ -166,7 +166,7 @@ button {
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%);
+    translate: -50% -50%;
     height: 350px;
     width: 350px;
     background-color: #e7f1f1;


### PR DESCRIPTION
## What is the feature?
This adds a user modal asking for confirmation when attempting to delete a saved palette.

## How you implemented the solution?
The meat of the changes here is `await`-ing for a `Promise` from the user interaction within the confirmation modal.
I encourage you to read up on this new tech, since it was the only way I could find to pause within an already firing eventListener, and wait for an interaction from another listener.
[https://javascript.info/asyn](https://javascript.info/async)

## Any changes in the UI (Screenshots)?
<img width="1006" alt="Screenshot 2023-04-14 at 3 46 23 PM" src="https://user-images.githubusercontent.com/32660020/232141332-c4d3337f-282f-4f25-9fdd-b13531ad466b.png">


## How to test the feature (A test scenario or any new setup)?
- Hitting the `X` in the top right corner of the modal will not delete the palette and exit the modal.
- Hitting the `Delete this palette` button confirms deletion of the palette and exits the modal.
  - Note that the palette deleted no longer appears in the 
- When the modal is open, interactions with other sections of the app should not be allowed!