### PR TITLE
Refactor/is palette unique function

### DIFF
--- a/main.js
+++ b/main.js
@@ -114,7 +114,6 @@ function savePalette() {
 
 function isPaletteUnique(palettesList, singlePalette) {
     for (var i = 0; i < palettesList.length; i++) {
-        console.log('isPaletteUnique', i);
         if (areArraysEquivalent(palettesList[i], singlePalette)) {
             return false;
         } 
@@ -122,10 +121,9 @@ function isPaletteUnique(palettesList, singlePalette) {
     return true;   
 }    
 
-function areArraysEquivalent(array1, array2) {
-    for (var i = 0; i < array1.length; i++) {
-        console.log('areArraysEquivalent', i);
-        if (array1[i] !== array2[i]) {
+function areArraysEquivalent(palettesToCheck, currentPalette) {
+    for (var i = 0; i < palettesToCheck.length; i++) {
+        if (palettesToCheck[i] !== currentPalette[i]) {
             return false;
         }
     }

--- a/main.js
+++ b/main.js
@@ -112,20 +112,25 @@ function savePalette() {
     getNewHexes(mainColorBoxes);
 }
 
+
 function isPaletteUnique(palettesList, singlePalette) {
     for (i = 0; i < palettesList.length; i++) {
-        var matches = true;
-        for (j = 0; j < palettesList[i].length; j++) {
-            if (palettesList[i][j] !== singlePalette[j]) {
-                matches = false;
-                break;
-            }
-        }
-        if (matches) {
+        if (areArraysEquivalent(palettesList[i], singlePalette)) {
             return false;
+        } 
+    }
+    return true;   
+}    
+
+function areArraysEquivalent(array1, array2) {
+    var matches = true;
+    for (i = 0; i < array1.length; i++) {
+        if (array1[i] !== array2[i]) {
+            matches = false;
+            break;
         }
-    }    
-    return true;
+    }
+    return matches;
 }
 
 function deletePalette(savedPalette, savedPalettesIndex) {

--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ function getNewHexes(mainDisplayedColors) {
     var oldHexes = currentPalette;
     currentPalette = [];
     var newColor;
-    for(i = 0; i < mainDisplayedColors.length; i++) {
+    for(var i = 0; i < mainDisplayedColors.length; i++) {
         var thisColorBoxLock = mainDisplayedColors[i].firstElementChild.firstElementChild;
         if(thisColorBoxLock.classList.contains('unlocked')) {
             newColor = getRandomHex();
@@ -144,7 +144,7 @@ function addPaletteToSavedPalettes(palette) {
     var newMiniContainer = document.createElement('div');
     newMiniContainer.classList.add('mini-container', 'hover');
     savedPalettesSection.appendChild(newMiniContainer);
-    for (i = 0; i < palette.length; i++) {
+    for (var i = 0; i < palette.length; i++) {
         newMiniContainer.innerHTML += `<div class="mini-box", style="background-color: #${palette[i]}"></div>`
     }
     newMiniContainer.innerHTML += `<img class="delete-button" src='./assets/delete.png'></img>`
@@ -182,7 +182,7 @@ function rgbToHex(rgbNumbers) {
 
 function displayMainColours(savedPalette) {
     currentPalette = savedPalette;
-    for (i = 0; i < savedPalette.length; i++) {
+    for (var i = 0; i < savedPalette.length; i++) {
         mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${savedPalette[i]}`;
         mainColorBoxes[i].lastElementChild.innerText = `#${savedPalette[i]}`;
     }

--- a/main.js
+++ b/main.js
@@ -112,9 +112,9 @@ function savePalette() {
     getNewHexes(mainColorBoxes);
 }
 
-
 function isPaletteUnique(palettesList, singlePalette) {
-    for (i = 0; i < palettesList.length; i++) {
+    for (var i = 0; i < palettesList.length; i++) {
+        console.log('isPaletteUnique', i);
         if (areArraysEquivalent(palettesList[i], singlePalette)) {
             return false;
         } 
@@ -123,14 +123,13 @@ function isPaletteUnique(palettesList, singlePalette) {
 }    
 
 function areArraysEquivalent(array1, array2) {
-    var matches = true;
-    for (i = 0; i < array1.length; i++) {
+    for (var i = 0; i < array1.length; i++) {
+        console.log('areArraysEquivalent', i);
         if (array1[i] !== array2[i]) {
-            matches = false;
-            break;
+            return false;
         }
     }
-    return matches;
+    return true;
 }
 
 function deletePalette(savedPalette, savedPalettesIndex) {


### PR DESCRIPTION
## What is the feature?
Refactor isPaletteUnique function to call areArraysEqual function to eliminate double for loop.
Changed all `for (i = 0` to `for (var i = 0` to prevent `i` from being a global variable, or to scope `i` to each function individually.

## How you implemented the solution?
Separated out the individual for loops inside isPaletteUnique function.

## Does it impact any other area of the project?
It should only prevent future bugs where `i` was declared as a global variable.

## Any changes in the UI (Screenshots)?
None
## How to test the feature (A test scenario or any new setup)?
Save palette, save palette, click on saved palette, save palette again. It shouldn't save.
