### PR TITLE
User-added palette names

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,11 @@
         <div class="modal-window hidden" id="namePaletteModal">
             <span id="saveModalText">Would you like to name this palette? (Leave blank if not)</span>
             <input id="paletteNameInput" placeholder="Type name here..."></input>
-            <button id="savePaletteButton">Save</button>
+            <div class="hover button-area">
+                <div class="button-box-l delete-palette-button"></div>
+                <button id="savePaletteButton">Save</button>
+                <div class="button-box-r delete-palette-button"></div>
+            </div>
         </div>
         <div class="modal-window hidden" id="deletePaletteModal">
             <img class="modal-exit-button hover" src='./assets/delete.png'></img>

--- a/index.html
+++ b/index.html
@@ -68,19 +68,19 @@
         <div class="modal-window hidden" id="namePaletteModal">
             <span id="saveModalText">Would you like to name this palette? (Leave blank if not)</span>
             <input id="paletteNameInput" placeholder="Type name here..."></input>
-            <div class="hover button-area">
-                <div class="button-box-l delete-palette-button"></div>
-                <button id="savePaletteButton">Save</button>
-                <div class="button-box-r delete-palette-button"></div>
+            <div class="hover button-area" id="confirmSaveButtonArea">
+                <div class="button-box-l confirm-save-palette-button"></div>
+                <button class="confirm-save-palette-button" id="savePaletteButton">Save</button>
+                <div class="button-box-r confirm-save-palette-button"></div>
             </div>
         </div>
         <div class="modal-window hidden" id="deletePaletteModal">
             <img class="modal-exit-button hover" src='./assets/delete.png'></img>
             <span id="deleteModalText">Are you sure you want to delete this palette?</span>
             <div class="hover button-area">
-                <div class="button-box-l delete-palette-button"></div>
-                <button id="deletePaletteButton">Delete this palette</button>
-                <div class="button-box-r delete-palette-button"></div>
+                <div class="button-box-l confirm-delete-palette-button"></div>
+                <button class="confirm-delete-palette-button" id="deletePaletteButton">Delete this palette</button>
+                <div class="button-box-r confirm-delete-palette-button"></div>
             </div>
         </div>
         <script src="./main.js"></script>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         </section>
         <div class="modal-window hidden" id="namePaletteModal">
             <span id="saveModalText">Would you like to name this palette? (Leave blank if not)</span>
-            <input placeholder="Type name here..."></input>
+            <input id="paletteNameInput" placeholder="Type name here..."></input>
             <button id="savePaletteButton">Save</button>
         </div>
         <div class="modal-window hidden" id="deletePaletteModal">

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
             <header>
                 <h1>COLORANDOM</h1>
             </header>
+            <span class="hidden" id="paletteName"></span>
             <section class="main-display">
                 <div class="color-container">
                     <div class="color-box" id="b1">

--- a/index.html
+++ b/index.html
@@ -60,9 +60,14 @@
                 <!-- Saved palettes gets populated here -->
             </section>
         </section>
-        <div class="modal-window hidden">
+        <div class="modal-window hidden" id="namePaletteModal">
+            <span id="saveModalText">Would you like to name this palette? (Leave blank if not)</span>
+            <input placeholder="Type name here..."></input>
+            <button id="savePaletteButton">Save</button>
+        </div>
+        <div class="modal-window hidden" id="deletePaletteModal">
             <img class="modal-exit-button" src='./assets/delete.png'></img>
-            <span id="modalText">Are you sure you want to delete this palette?</span>
+            <span id="deletetModalText">Are you sure you want to delete this palette?</span>
             <button id="deletePaletteButton">Delete this palette</button>
         </div>
         <script src="./main.js"></script>

--- a/main.js
+++ b/main.js
@@ -76,6 +76,7 @@ function modalClassToggler() {
 }
 
 function getNewHexes(mainDisplayedColors) {
+    paletteName.classList.add('hidden');
     var oldHexes = currentPalette.hexes;
     currentPalette = {
         hexes: [],
@@ -205,10 +206,15 @@ function rgbToHex(rgbNumbers) {
 
 function displayMainColours(savedPalette) {
     currentPalette = savedPalette;
-    paletteName.innerText = `palette name: "${currentPalette.name}"`;
-    paletteName.classList.remove('hidden');
-    for (i = 0; i < savedPalette.length; i++) {
-        mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${savedPalette[i]}`;
-        mainColorBoxes[i].lastElementChild.innerText = `#${savedPalette[i]}`;
+    if (savedPalette.name) {
+        paletteName.innerText = `palette name: "${currentPalette.name}"`;
+        paletteName.classList.remove('hidden');
+    } else {
+        paletteName.classList.add('hidden');
+    }
+    
+    for (i = 0; i < currentPalette.hexes.length; i++) {
+        mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${savedPalette.hexes[i]}`;
+        mainColorBoxes[i].lastElementChild.innerText = `#${savedPalette.hexes[i]}`;
     }
 }

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ var currentPalette = {};
 var shouldDelete = false;
 
 var main = document.querySelector('main');
+var paletteName = document.getElementById('paletteName')
 var savedContainer = document.querySelector('.save-container');
 var buttonSection = document.querySelector('.button-area');
 var newPaletteButton = document.querySelector('button');
@@ -176,15 +177,12 @@ function addPaletteToSavedPalettes(palette) {
 }
 
 function getSavedPalette(event) {
-    var color;
-    var savedColors = [];
     if (event.target.classList.contains('mini-box')) {
-        for (var i = 0; i < event.target.parentNode.children.length - 1; i++) {
-            color = event.target.parentNode.children[i].style.backgroundColor;
-            savedColors[i] = rgbToHex(rgbToNumbers(color));
-        }
+        var eventTargetParent = event.target.parentNode;
+        var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
+        var thisSavedPalette = savedPalettes[thisSavedPaletteIndex];
+        return thisSavedPalette;
     }
-    return savedColors;
 }
 
 function rgbToNumbers(rgbString) {
@@ -207,6 +205,8 @@ function rgbToHex(rgbNumbers) {
 
 function displayMainColours(savedPalette) {
     currentPalette = savedPalette;
+    paletteName.innerText = `palette name: "${currentPalette.name}"`;
+    paletteName.classList.remove('hidden');
     for (i = 0; i < savedPalette.length; i++) {
         mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${savedPalette[i]}`;
         mainColorBoxes[i].lastElementChild.innerText = `#${savedPalette[i]}`;

--- a/main.js
+++ b/main.js
@@ -136,7 +136,7 @@ function getPromiseFromConfirmSave(element, listenerName) {
                 saveModalText.innerText = 'Name already taken! Name this palette something else?';
                 saveModalText.setAttribute('id', 'validation');
                 saveModalText.style.fontStyle = 'italic';
-                await getPromiseFromEvent2(confirmSaveButtonArea, 'click');
+                await getPromiseFromConfirmSave(confirmSaveButtonArea, 'click');
             }
             resolve(event);
             element.removeEventListener(listenerName, listener);

--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ buttonSection.addEventListener('click', function(event) {
 savedPalettesSection.addEventListener('click', async function(event) {
     if (event.target.classList.contains('delete-button')) {
         modalClassToggler([[deleteModal, 'hidden'], [main, 'block'], [savedContainer, 'block']]);
-        await getPromiseFromEvent(deleteModal);
+        await getPromiseFromConfirmDelete(deleteModal);
         if (shouldDelete) {
             var eventTargetParent = event.target.parentNode.parentNode;
             var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
@@ -55,7 +55,7 @@ savedPalettesSection.addEventListener('click', async function(event) {
     }
 });
 
-function getPromiseFromEvent(event) {
+function getPromiseFromConfirmDelete(event) {
     return new Promise(function (resolve) {
         event.addEventListener('click', listener);
         function listener(event) {
@@ -117,7 +117,7 @@ async function savePalette() {
         paragraph.classList.add('hidden');
     } 
     if (isPaletteUnique(savedPalettes, currentPalette)) {
-        await getPromiseFromEvent2(confirmSaveButtonArea, 'click');
+        await getPromiseFromConfirmSave(confirmSaveButtonArea, 'click');
         savedPalettes.push(currentPalette);
         addPaletteToSavedPalettes(currentPalette);
     }
@@ -125,7 +125,7 @@ async function savePalette() {
     getNewHexes(mainColorBoxes);
 }
 
-function getPromiseFromEvent2(element, listenerName) {
+function getPromiseFromConfirmSave(element, listenerName) {
     return new Promise(function (resolve) {
         async function listener(event) {
             if (event.target.classList.contains('confirm-save-palette-button')) {

--- a/main.js
+++ b/main.js
@@ -40,14 +40,14 @@ buttonSection.addEventListener('click', function(event) {
 
 savedPalettesSection.addEventListener('click', async function(event) {
     if (event.target.classList.contains('delete-button')) {
-        modalClassToggler();
+        modalClassToggler([[deleteModal, 'hidden'], [main, 'block'], [savedContainer, 'block']]);
         await getPromiseFromEvent(deleteModal, 'click');
         if (shouldDelete) {
             var eventTargetParent = event.target.parentNode;
             var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
             deletePalette(eventTargetParent, thisSavedPaletteIndex);
         } 
-        modalClassToggler();
+        modalClassToggler([[deleteModal, 'hidden'], [main, 'block'], [savedContainer, 'block']]);
         shouldDelete = false;
     } else if (event.target.classList.contains('mini-box')) {
         displayMainColours(getSavedPalette(event));
@@ -69,10 +69,11 @@ function getPromiseFromEvent(element, listenerName) {
     });
 }
 
-function modalClassToggler() {
-    deleteModal.classList.toggle('hidden');
-    main.classList.toggle('block');
-    savedContainer.classList.toggle('block');
+function modalClassToggler(elementsClasses) {
+    for (var i = 0; i < elementsClasses.length; i++) {
+        console.log(elementsClasses[i][0].classList)
+        elementsClasses[i][0].classList.toggle(elementsClasses[i][1]);
+    }
 }
 
 function getNewHexes(mainDisplayedColors) {
@@ -110,7 +111,7 @@ function getRandomHex() {
 }
 
 async function savePalette() {
-    modalClassToggler2();
+    modalClassToggler([[saveModal, 'hidden'], [main, 'block'], [savedContainer, 'block']]);
     if (!savedPalettes.length) {
         paragraph.classList.add('hidden');
     } 
@@ -119,7 +120,7 @@ async function savePalette() {
         savedPalettes.push(currentPalette);
         addPaletteToSavedPalettes(currentPalette);
     }
-    modalClassToggler2();
+    modalClassToggler([[saveModal, 'hidden'], [main, 'block'], [savedContainer, 'block']]);
     getNewHexes(mainColorBoxes);
 }
 
@@ -135,12 +136,6 @@ function getPromiseFromEvent2(element, listenerName) {
         };
         element.addEventListener(listenerName, listener);
     });
-}
-
-function modalClassToggler2() {
-    saveModal.classList.toggle('hidden');
-    main.classList.toggle('block');
-    savedContainer.classList.toggle('block');
 }
 
 function isPaletteUnique(savedPalettes, currentPalette) {

--- a/main.js
+++ b/main.js
@@ -130,8 +130,8 @@ function getPromiseFromEvent2(element, listenerName) {
             if (event.target.classList.contains('confirm-save-palette-button')) {
                 currentPalette.name = saveModalInput.value;
                 saveModalInput.value = ''
-                resolve(event);
             }
+            resolve(event);
             element.removeEventListener(listenerName, listener);
         };
         element.addEventListener(listenerName, listener);
@@ -157,6 +157,7 @@ function isPaletteUnique(savedPalettes, currentPalette) {
 function deletePalette(savedPalette, savedPalettesIndex) {
     savedPalettes.splice(savedPalettesIndex, 1);
     savedPalette.remove();
+    paletteName.classList.add('hidden');
     if (!savedPalettes.length) {
         paragraph.classList.remove('hidden');
     }
@@ -211,7 +212,7 @@ function rgbToHex(rgbNumbers) {
 
 function displayMainColours(savedPalette) {
     currentPalette = savedPalette;
-    if (savedPalette.name) {
+    if (currentPalette.name) {
         paletteName.innerText = `palette name: "${currentPalette.name}"`;
         paletteName.classList.remove('hidden');
     } else {
@@ -219,7 +220,7 @@ function displayMainColours(savedPalette) {
     }
     
     for (i = 0; i < currentPalette.hexes.length; i++) {
-        mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${savedPalette.hexes[i]}`;
-        mainColorBoxes[i].lastElementChild.innerText = `#${savedPalette.hexes[i]}`;
+        mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${currentPalette.hexes[i]}`;
+        mainColorBoxes[i].lastElementChild.innerText = `#${currentPalette.hexes[i]}`;
     }
 }

--- a/main.js
+++ b/main.js
@@ -118,6 +118,7 @@ async function savePalette() {
     } 
     if (isPaletteUnique(savedPalettes, currentPalette)) {
         await getPromiseFromConfirmSave(confirmSaveButtonArea, 'click');
+        saveModalText.innerText = 'Would you like to name this palette? (Leave blank if not)';
         savedPalettes.push(currentPalette);
         addPaletteToSavedPalettes(currentPalette);
     }
@@ -130,7 +131,7 @@ function getPromiseFromConfirmSave(element, listenerName) {
         async function listener(event) {
             if (event.target.classList.contains('confirm-save-palette-button')) {
                 currentPalette.name = saveModalInput.value;
-                saveModalInput.value = ''
+                saveModalInput.value = '';
             }
             if (currentPalette.name.length && !isPaletteNameUnique(currentPalette.name)) {
                 saveModalText.innerText = 'Name already taken! Name this palette something else?';
@@ -159,7 +160,6 @@ function arePalettesEquivalent(savedPaletteToCheck, currentPalette) {
     for (var i = 0; i < savedPaletteToCheck.length; i++) {
         if (savedPaletteToCheck[i] !== currentPalette[i]) {
             return false;
-            break;
         }
     }
     return true;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 var savedPalettes = [];
-var currentPalette = [];
+var currentPalette = {};
 var shouldDelete = false;
 
 var main = document.querySelector('main');
@@ -9,7 +9,10 @@ var newPaletteButton = document.querySelector('button');
 var mainColorBoxes = document.querySelectorAll('.color-container');
 var lockButton = document.querySelector('.main-display');
 var savedPalettesSection = document.querySelector('.mini-palettes');
-var deleteModal = document.querySelector('.modal-window');
+var saveModal = document.getElementById('namePaletteModal');
+var saveModalInput = document.querySelector('input');
+var saveModalButton = document.getElementById('savePaletteButton');
+var deleteModal = document.getElementById('deletePaletteModal');
 var paragraph = document.querySelector('p');
 
 window.addEventListener('load', function() {
@@ -72,8 +75,11 @@ function modalClassToggler() {
 }
 
 function getNewHexes(mainDisplayedColors) {
-    var oldHexes = currentPalette;
-    currentPalette = [];
+    var oldHexes = currentPalette.hexes;
+    currentPalette = {
+        hexes: [],
+        name: ''
+    };
     var newColor;
     for (i = 0; i < mainDisplayedColors.length; i++) {
         var thisColorBoxLock = mainDisplayedColors[i].firstElementChild.firstElementChild;
@@ -81,9 +87,9 @@ function getNewHexes(mainDisplayedColors) {
             newColor = getRandomHex();
             mainDisplayedColors[i].firstElementChild.style.backgroundColor = `#${newColor}`;
             mainDisplayedColors[i].lastElementChild.innerText = `#${newColor}`;
-            currentPalette.push(newColor);
+            currentPalette.hexes.push(newColor);
         } else { 
-            currentPalette.push(oldHexes[i]);
+            currentPalette.hexes.push(oldHexes[i]);
         }
     }
 }
@@ -101,22 +107,45 @@ function getRandomHex() {
     return (Math.floor(Math.random() * 16777216).toString(16).padStart(6, 0)).toUpperCase();
 }
 
-function savePalette() {
+async function savePalette() {
+    modalClassToggler2();
     if (!savedPalettes.length) {
         paragraph.classList.add('hidden');
     } 
     if (isPaletteUnique(savedPalettes, currentPalette)) {
+        await getPromiseFromEvent2(saveModalButton, 'click');
         savedPalettes.push(currentPalette);
         addPaletteToSavedPalettes(currentPalette);
     }
+    modalClassToggler2();
     getNewHexes(mainColorBoxes);
 }
 
-function isPaletteUnique(palettesList, singlePalette) {
-    for (i = 0; i < palettesList.length; i++) {
+function getPromiseFromEvent2(element, listenerName) {
+    return new Promise(function (resolve) {
+        function listener(event) {
+            if (event.target.nodeName === 'BUTTON') {
+                currentPalette.name = saveModalInput.value;
+                saveModalInput.value = ''
+            }
+            element.removeEventListener(listenerName, listener);
+            resolve(event);
+        };
+        element.addEventListener(listenerName, listener);
+    });
+}
+
+function modalClassToggler2() {
+    saveModal.classList.toggle('hidden');
+    main.classList.toggle('block');
+    savedContainer.classList.toggle('block');
+}
+
+function isPaletteUnique(savedPalettes, currentPalette) {
+    for (i = 0; i < savedPalettes.length; i++) {
         var matches = true;
-        for (j = 0; j < palettesList[i].length; j++) {
-            if (palettesList[i][j] !== singlePalette[j]) {
+        for (j = 0; j < savedPalettes[i].hexes.length; j++) {
+            if (savedPalettes[i].hexes[j] !== currentPalette.hexes[j]) {
                 matches = false;
                 break;
             }
@@ -140,8 +169,8 @@ function addPaletteToSavedPalettes(palette) {
     var newMiniContainer = document.createElement('div');
     newMiniContainer.classList.add('mini-container', 'hover');
     savedPalettesSection.appendChild(newMiniContainer);
-    for (i = 0; i < palette.length; i++) {
-        newMiniContainer.innerHTML += `<div class="mini-box", style="background-color: #${palette[i]}"></div>`;
+    for (i = 0; i < palette.hexes.length; i++) {
+        newMiniContainer.innerHTML += `<div class="mini-box", style="background-color: #${palette.hexes[i]}"></div>`;
     }
     newMiniContainer.innerHTML += `<img class="delete-button" src='./assets/delete.png'></img>`;
 }

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ var lockButton = document.querySelector('.main-display');
 var savedPalettesSection = document.querySelector('.mini-palettes');
 var saveModal = document.getElementById('namePaletteModal');
 var saveModalInput = document.querySelector('input');
-var saveModalButton = document.getElementById('savePaletteButton');
+var saveModalButtonArea = document.getElementById('confirmSaveButtonArea');
 var deleteModal = document.getElementById('deletePaletteModal');
 var paragraph = document.querySelector('p');
 
@@ -62,7 +62,7 @@ function getPromiseFromEvent(event) {
             if (event.target.classList.contains('modal-exit-button')) {
                 shouldDelete = false;
                 resolve(event);
-            } else if (event.target.classList.contains('delete-palette-button')) {
+            } else if (event.target.classList.contains('confirm-delete-palette-button')) {
                 shouldDelete = true;
                 resolve(event);
             }
@@ -116,7 +116,7 @@ async function savePalette() {
         paragraph.classList.add('hidden');
     } 
     if (isPaletteUnique(savedPalettes, currentPalette)) {
-        await getPromiseFromEvent2(saveModalButton, 'click');
+        await getPromiseFromEvent2(confirmSaveButtonArea, 'click');
         savedPalettes.push(currentPalette);
         addPaletteToSavedPalettes(currentPalette);
     }
@@ -127,12 +127,12 @@ async function savePalette() {
 function getPromiseFromEvent2(element, listenerName) {
     return new Promise(function (resolve) {
         function listener(event) {
-            if (event.target.nodeName === 'BUTTON') {
+            if (event.target.classList.contains('confirm-save-palette-button')) {
                 currentPalette.name = saveModalInput.value;
                 saveModalInput.value = ''
+                resolve(event);
             }
             element.removeEventListener(listenerName, listener);
-            resolve(event);
         };
         element.addEventListener(listenerName, listener);
     });

--- a/main.js
+++ b/main.js
@@ -125,7 +125,6 @@ async function savePalette() {
     getNewHexes(mainColorBoxes);
 }
 
-<<<<<<< HEAD
 function getPromiseFromEvent2(element, listenerName) {
     return new Promise(function (resolve) {
         async function listener(event) {
@@ -147,30 +146,20 @@ function getPromiseFromEvent2(element, listenerName) {
 }
 
 function isPaletteUnique(savedPalettes, currentPalette) {
+    var isUnique = true;
     for (var i = 0; i < savedPalettes.length; i++) {
-        var matches = true;
-        for (var j = 0; j < savedPalettes[i].hexes.length; j++) {
-            if (savedPalettes[i].hexes[j] !== currentPalette.hexes[j]) {
-                matches = false;
-                break;
-            }
+        if (arePalettesEquivalent(savedPalettes[i].hexes, currentPalette.hexes)) {
+            isUnique = false;
         }
-        if (matches) {
-=======
-function isPaletteUnique(palettesList, singlePalette) {
-    for (var i = 0; i < palettesList.length; i++) {
-        if (areArraysEquivalent(palettesList[i], singlePalette)) {
-            return false;
-        } 
     }
-    return true;   
-}    
+    return isUnique;
+}
 
-function areArraysEquivalent(palettesToCheck, currentPalette) {
-    for (var i = 0; i < palettesToCheck.length; i++) {
-        if (palettesToCheck[i] !== currentPalette[i]) {
->>>>>>> main
+function arePalettesEquivalent(savedPaletteToCheck, currentPalette) {
+    for (var i = 0; i < savedPaletteToCheck.length; i++) {
+        if (savedPaletteToCheck[i] !== currentPalette[i]) {
             return false;
+            break;
         }
     }
     return true;
@@ -210,6 +199,7 @@ function addPaletteToSavedPalettes(palette) {
 
     for (var i = 0; i < palette.hexes.length; i++) {
         newMiniColorsContainer.innerHTML += `<div class="mini-box", style="background-color: #${palette.hexes[i]}"></div>`;
+    }
 
     newMiniContainer.appendChild(newHoverContainer);
     newHoverContainer.innerHTML += `<img class="delete-button" src='./assets/delete.png'></img>`;

--- a/main.js
+++ b/main.js
@@ -137,7 +137,9 @@ function getPromiseFromConfirmSave(element, listenerName) {
                 saveModalText.innerText = 'Name already taken! Name this palette something else?';
                 saveModalText.setAttribute('id', 'validation');
                 saveModalText.style.fontStyle = 'italic';
+                element.removeEventListener(listenerName, listener);
                 await getPromiseFromConfirmSave(confirmSaveButtonArea, 'click');
+                element.addEventListener(listenerName, listener);
             }
             resolve(event);
             element.removeEventListener(listenerName, listener);

--- a/main.js
+++ b/main.js
@@ -51,7 +51,7 @@ savedPalettesSection.addEventListener('click', async function(event) {
         modalClassToggler([[deleteModal, 'hidden'], [main, 'block'], [savedContainer, 'block']]);
         shouldDelete = false;
     } else if (event.target.classList.contains('mini-box')) {
-        displayMainColours(getSavedPalette(event));
+        displayMainColours(getSavedPalette(event.target));
     }
 });
 
@@ -200,13 +200,11 @@ function addPaletteToSavedPalettes(palette) {
     newHoverContainer.innerHTML += `<img class="delete-button" src='./assets/delete.png'></img>`;
 }
 
-function getSavedPalette(event) {
-    if (event.target.classList.contains('mini-box')) {
-        var eventTargetParent = event.target.parentNode;
-        var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
-        var thisSavedPalette = savedPalettes[thisSavedPaletteIndex];
-        return thisSavedPalette;
-    }
+function getSavedPalette(eventTarget) {
+    var eventTargetParent = eventTarget.parentNode.parentNode;
+    var thisSavedPaletteIndex = Array.from(eventTargetParent.parentNode.children).indexOf(eventTargetParent);
+    var thisSavedPalette = savedPalettes[thisSavedPaletteIndex];
+    return thisSavedPalette;
 }
 
 function rgbToNumbers(rgbString) {
@@ -229,14 +227,14 @@ function rgbToHex(rgbNumbers) {
 
 function displayMainColours(savedPalette) {
     currentPalette = savedPalette;
-    if (currentPalette.name) {
+    if (currentPalette.name.length) {
         paletteName.innerText = `palette name: "${currentPalette.name}"`;
         paletteName.classList.remove('hidden');
     } else {
         paletteName.classList.add('hidden');
     }
     
-    for (i = 0; i < currentPalette.hexes.length; i++) {
+    for (var i = 0; i < currentPalette.hexes.length; i++) {
         mainColorBoxes[i].firstElementChild.style.backgroundColor = `#${currentPalette.hexes[i]}`;
         mainColorBoxes[i].lastElementChild.innerText = `#${currentPalette.hexes[i]}`;
     }

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ var mainColorBoxes = document.querySelectorAll('.color-container');
 var lockButton = document.querySelector('.main-display');
 var savedPalettesSection = document.querySelector('.mini-palettes');
 var saveModal = document.getElementById('namePaletteModal');
+var saveModalText = document.getElementById('saveModalText');
 var saveModalInput = document.querySelector('input');
 var saveModalButtonArea = document.getElementById('confirmSaveButtonArea');
 var deleteModal = document.getElementById('deletePaletteModal');
@@ -57,7 +58,6 @@ savedPalettesSection.addEventListener('click', async function(event) {
 function getPromiseFromEvent(event) {
     return new Promise(function (resolve) {
         event.addEventListener('click', listener);
-
         function listener(event) {
             if (event.target.classList.contains('modal-exit-button')) {
                 shouldDelete = false;
@@ -126,10 +126,16 @@ async function savePalette() {
 
 function getPromiseFromEvent2(element, listenerName) {
     return new Promise(function (resolve) {
-        function listener(event) {
+        async function listener(event) {
             if (event.target.classList.contains('confirm-save-palette-button')) {
                 currentPalette.name = saveModalInput.value;
                 saveModalInput.value = ''
+            }
+            if (currentPalette.name.length && !isPaletteNameUnique(currentPalette.name)) {
+                saveModalText.innerText = 'Name already taken! Name this palette something else?';
+                saveModalText.setAttribute('id', 'validation');
+                saveModalText.style.fontStyle = 'italic';
+                await getPromiseFromEvent2(confirmSaveButtonArea, 'click');
             }
             resolve(event);
             element.removeEventListener(listenerName, listener);
@@ -139,9 +145,9 @@ function getPromiseFromEvent2(element, listenerName) {
 }
 
 function isPaletteUnique(savedPalettes, currentPalette) {
-    for (i = 0; i < savedPalettes.length; i++) {
+    for (var i = 0; i < savedPalettes.length; i++) {
         var matches = true;
-        for (j = 0; j < savedPalettes[i].hexes.length; j++) {
+        for (var j = 0; j < savedPalettes[i].hexes.length; j++) {
             if (savedPalettes[i].hexes[j] !== currentPalette.hexes[j]) {
                 matches = false;
                 break;
@@ -152,6 +158,17 @@ function isPaletteUnique(savedPalettes, currentPalette) {
         }
     }    
     return true;
+}
+
+function isPaletteNameUnique(name) {
+    var matches = true;
+    for (var i = 0; i < savedPalettes.length; i++) {
+        if (savedPalettes[i].name === name) {
+            matches = false;
+            break;
+        }
+    }
+    return matches;
 }
 
 function deletePalette(savedPalette, savedPalettesIndex) {

--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,7 @@ button {
     display: inline-flex;
     flex-direction: column;
     align-items: center;
+    text-align: center;
     justify-content: space-around;
     position: absolute;
     top: 50%;
@@ -168,6 +169,19 @@ button {
 #deletePaletteButton {
     border-radius: 15px;
     padding: 10px;
+}
+
+#savePaletteButton {
+    border-radius: 15px;
+    padding: 10px;
+}
+
+#paletteNameInput {
+    height: 50px;
+    width: 250px;
+    text-align: center;
+    font-size: x-large;
+    font-weight: 300;
 }
 
 .modal-exit-button {

--- a/styles.css
+++ b/styles.css
@@ -167,17 +167,6 @@ button {
     text-align: center;
 }
 
-<<<<<<< HEAD
-#deletePaletteButton {
-    border-radius: 15px;
-    padding: 10px;
-}
-
-#savePaletteButton {
-    border-radius: 15px;
-    padding: 10px;
-}
-
 #paletteNameInput {
     height: 50px;
     width: 250px;

--- a/styles.css
+++ b/styles.css
@@ -42,8 +42,7 @@ header {
 }
 
 #paletteName {
-    display: inline-flex;
-    justify-content: center;
+    text-align: center;
     font-size: x-large;
     font-weight: 500;
     font-style: italic;

--- a/styles.css
+++ b/styles.css
@@ -190,3 +190,17 @@ button {
     pointer-events: none;
     opacity: 0.3;
 }
+
+#validation {
+    animation: bounce 1s forwards;
+}
+
+@keyframes bounce {
+    0% { transform: translateY(0%) }
+    10% { transform: translateY(-15%) }
+    20% { transform: translateY(0%) }
+    25% { transform: translateY(-7%) }
+    27% { transform: translateY(0%) }
+    29% { transform: translateY(-3%) }
+    30% { transform: translateY(0) }
+}

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,14 @@ header {
     text-align: center;
 }
 
+#paletteName {
+    display: inline-flex;
+    justify-content: center;
+    font-size: x-large;
+    font-weight: 500;
+    font-style: italic;
+}
+
 .main-display,
 .button-area {
     display: flex;


### PR DESCRIPTION
## What is the feature?
This will allow the user to add their own custom names to the palettes they create!

## How you implemented the solution?
- First, the data model was updated to an object, containing keys for `hexes` and `name` to facilitate these changes change.
- A save modal, which borrows styling from our delete confirmation modal), prompts the user to type and save a name for their generated palette.
- If user selects a palette from their saved section that had been named, the name is also revealed just above the revisited palette.

## Does it impact any other area of the project?
It impacts almost every part of the project.

## Any changes in the UI (Screenshots)?
<img width="887" alt="Screenshot 2023-04-16 at 12 00 11 AM" src="https://user-images.githubusercontent.com/32660020/232265712-9c26b9fe-c9ec-423f-85f4-d4bfe624e6cd.png">

## How to test the feature?
- User can save palette with or without name entered
  - All palettes still appear in the saved section
- Retrieving saved palettes
  - Retrieving a saved palette that has a name shows that name along with the correct colors in the main section
  - Retrieving a saved palette that doesn't have a name shows just the colors and no name