### PR TITLE
Force dom reset with correct save modal styling

### DIFF
--- a/main.js
+++ b/main.js
@@ -119,6 +119,8 @@ async function savePalette() {
     if (isPaletteUnique(savedPalettes, currentPalette)) {
         await getPromiseFromConfirmSave(confirmSaveButtonArea, 'click');
         saveModalText.innerText = 'Would you like to name this palette? (Leave blank if not)';
+        saveModalText.removeAttribute('id', 'validation');
+        saveModalText.style.fontStyle = "normal";
         savedPalettes.push(currentPalette);
         addPaletteToSavedPalettes(currentPalette);
     }
@@ -134,6 +136,8 @@ function getPromiseFromConfirmSave(element, listenerName) {
                 saveModalInput.value = '';
             }
             if (currentPalette.name.length && !isPaletteNameUnique(currentPalette.name)) {
+                saveModalText.removeAttribute('id', 'validation');
+                element.offsetWidth;
                 saveModalText.innerText = 'Name already taken! Name this palette something else?';
                 saveModalText.setAttribute('id', 'validation');
                 saveModalText.style.fontStyle = 'italic';


### PR DESCRIPTION
## What is the feature?
Bugfix
## How you implemented the solution?
Force dom reset to apply correct styles/animation per: [https://gist.github.com/paulirish/5d52fb081b3570c81e3a](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)

## How to test the feature (A test scenario or any new setup)?
- Save functionality still works
- Correct styling is applied on the save modal text
  - emphasis on the `bounce` appearing when it should!
